### PR TITLE
Add Windows support

### DIFF
--- a/src/main/java/SuperCapsule.java
+++ b/src/main/java/SuperCapsule.java
@@ -8,6 +8,8 @@
 
 import capsule.posix.PosixSuperCapsule;
 import capsule.SuperCapsuleImpl;
+import capsule.windows.WindowsFFISuperCapsule;
+
 import java.nio.file.Path;
 
 /**
@@ -28,6 +30,8 @@ public class SuperCapsule extends Capsule implements capsule.CapsuleAPI {
     }
 
     private SuperCapsuleImpl createImpl() {
+        if (isWindows())
+            return new WindowsFFISuperCapsule(this);
         return new PosixSuperCapsule(this);
     }
 

--- a/src/main/java/capsule/posix/PosixSuperCapsule.java
+++ b/src/main/java/capsule/posix/PosixSuperCapsule.java
@@ -36,15 +36,15 @@ public class PosixSuperCapsule extends SuperCapsuleImpl {
         return posix.execve(path(pb), argv(pb), envp(pb));
     }
 
-    private static String path(ProcessBuilder pb) {
+    protected static String path(ProcessBuilder pb) {
         return pb.command().get(0);
     }
 
-    private static String[] argv(ProcessBuilder pb) {
+    protected static String[] argv(ProcessBuilder pb) {
         return toArray(pb.command().subList(0, pb.command().size()));
     }
 
-    private static String[] envp(ProcessBuilder pb) {
+    protected static String[] envp(ProcessBuilder pb) {
         List<String> env = new ArrayList<>();
         for (Map.Entry<String, String> pair : pb.environment().entrySet())
             env.add(pair.getKey() + '=' + pair.getValue());

--- a/src/main/java/capsule/windows/WindowsFFISuperCapsule.java
+++ b/src/main/java/capsule/windows/WindowsFFISuperCapsule.java
@@ -1,0 +1,26 @@
+package capsule.windows;
+
+import capsule.CapsuleAPI;
+import capsule.posix.PosixSuperCapsule;
+import jnr.ffi.LibraryLoader;
+
+/**
+ * @author circlespainter
+ */
+public class WindowsFFISuperCapsule extends PosixSuperCapsule {
+	public interface LibC {
+		int _execve(String path, String[] argv, String[] envp);
+	}
+
+	private final LibC libc;
+
+	public WindowsFFISuperCapsule(CapsuleAPI capsule) {
+		super(capsule);
+		this.libc = LibraryLoader.create(LibC.class).stdcall().load("msvcrt");
+	}
+
+	@Override
+	public int launch(ProcessBuilder pb) {
+		return libc._execve(path(pb), argv(pb), envp(pb));
+	}
+}


### PR DESCRIPTION
Not sure why the jnr-posix's compatibility layer doesn't work on Windows (deserves some more time perhaps) but it's just very easy to use jffi directly and call `msvcrt`'s `_execve` ([as recommended](https://msdn.microsoft.com/en-us/library/ms235493.aspx) it seems). There are only a few glitches:
- When running in `cmd`, when the initial Capsule process launches the actual application the prompt will be presented again to the user and the new executing image will behave as in background. I guess this is a Windows cmd prompt / `_execve` limit but maybe it deserves some investigation.
- There are some annoying but seemingly harmless Capsule exceptions upon termination.
